### PR TITLE
ci: use nix devshell for CI operations

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -11,15 +11,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Setup Rust
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
-          sudo snap install --classic rustup
-          rustup default stable
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@v16
 
       - name: Check formattting
-        run: cargo fmt --check
+        run: nix develop -c cargo fmt --check
 
       - name: Lint
-        run: cargo clippy
+        run: nix develop -c cargo clippy

--- a/.github/workflows/_spread-matrix.yml
+++ b/.github/workflows/_spread-matrix.yml
@@ -17,16 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
-
-      - name: Install
-        run: |
-          go install github.com/snapcore/spread/cmd/spread@latest
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@v16
 
       - name: Generate matrix list
         id: tests
         run: |
-          list="$(spread -list lxd | jq -r -ncR '[inputs | select(length>0)]')"
+          list="$(nix develop -c spread -list lxd | jq -r -ncR '[inputs | select(length>0)]')"
           echo "tests=$list"
           echo "tests=$list" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_spread.yml
+++ b/.github/workflows/_spread.yml
@@ -20,16 +20,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.23.0"
-
-      - name: Install
-        run: go install github.com/snapcore/spread/cmd/spread@latest
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@v16
 
       - name: Setup LXD
         uses: canonical/setup-lxd@v0.1.2
 
       - name: Run integration tests
-        run: spread -v "${{ matrix.test }}"
+        run: nix develop -c spread -v "${{ matrix.test }}"

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -11,15 +11,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Setup Rust
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
-          sudo snap install --classic rustup
-          rustup default stable
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@v16
 
       - name: Build
-        run: cargo build
+        run: nix develop -c cargo build
 
       - name: Unit tests
-        run: cargo test -- --show-output
+        run: nix develop -c cargo test -- --show-output

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,14 +32,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup goreleaser
-        run: |
-          sudo snap install --classic goreleaser
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@v16
 
       - name: Build oxidizr
         id: build
         run: |
-          goreleaser build --snapshot --clean --verbose
+          nix develop -c goreleaser build --snapshot --clean --verbose
 
   spread-tests:
     name: Spread tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup goreleaser
-        run: |
-          sudo snap install --classic goreleaser
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@v16
 
       - name: Release oxidizr
         id: build
         run: |
-          goreleaser release --clean --verbose
+          nix develop -c goreleaser release --clean --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,6 @@ project_name: oxidizr
 before:
   hooks:
     - rustup default stable
-    - cargo install cross --git https://github.com/cross-rs/cross
 
 builds:
   - builder: rust
@@ -14,7 +13,8 @@ builds:
     command: build
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     {
       self,
       nixpkgs,
-      rust-overlay,
+      ...
     }:
     let
       supportedSystems = [
@@ -23,7 +23,7 @@
         system:
         (import nixpkgs {
           inherit system;
-          overlays = [ (import rust-overlay) ];
+          overlays = [ self.inputs.rust-overlay.overlays.default ];
         });
     in
     {
@@ -64,7 +64,12 @@
         let
           pkgs = pkgsForSystem system;
           rust = pkgs.rust-bin.stable.latest.default.override {
-            extensions = [ "rust-src" ];
+            extensions = [
+              "rust-src"
+              "clippy"
+              "rust-analyzer"
+              "rustfmt"
+            ];
           };
         in
         {
@@ -74,11 +79,15 @@
             NIX_CONFIG = "experimental-features = nix-command flakes";
             RUST_SRC_PATH = "${rust}/lib/rustlib/src/rust/library";
 
-            inputsFrom = [ self.packages.${system}.oxidizr ];
-            buildInputs = with pkgs; [
-              clippy
-              rust
-            ];
+            buildInputs =
+              (with pkgs; [
+                cargo-cross
+                rustup
+                spread
+                goreleaser
+                jq
+              ])
+              ++ [ rust ];
           };
         }
       );


### PR DESCRIPTION
   
Install all dependencies and tools using a nix devshell to make troublshooting any difficulties more easy to reproduce in places other than Github.