### PR TITLE
Build binary for PowerPC64 LE

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,7 @@ builds:
     targets:
       - x86_64-unknown-linux-gnu
       - aarch64-unknown-linux-gnu
+      - powerpc64le-unknown-linux-gnu
     tool: "cross"
     command: build
 


### PR DESCRIPTION
Because Ubuntu still supports PowerPC64 Little Endian architecture. It is more convenient for the PowerPC community if oxidizr ships with ppc64le binary.