### PR TITLE
fix: use `dpkg-query` to check for installs

### DIFF
--- a/src/utils/worker.rs
+++ b/src/utils/worker.rs
@@ -57,10 +57,11 @@ pub trait Worker {
 
     /// Check if a package is installed using the system package manager.
     fn check_installed(&self, package: &str) -> Result<bool> {
-        let cmd = Command::build("apt", &["list", package]);
-        let output = self.run(&cmd)?;
-        let output = String::from_utf8(output.stdout)?.to_string();
-        Ok(output.contains("installed"))
+        let cmd = Command::build("dpkg-query", &["-s", package]);
+        match self.run(&cmd) {
+            Ok(_) => Ok(true),
+            Err(_) => Ok(false),
+        }
     }
 
     /// Replace a file with a symlink. If the target file already exists, it will be backed up.

--- a/tests/disable-in-german/task.yaml
+++ b/tests/disable-in-german/task.yaml
@@ -1,0 +1,26 @@
+summary: Test selectively disabling experiments when locale is not English
+execute: |
+  sed -i 's|# de_DE.UTF-8 UTF-8|de_DE.UTF-8 UTF-8|g' /etc/locale.gen
+  locale-gen
+
+  export LC_ALL=de_DE.UTF-8
+  export LANGUAGE=de_DE.UTF-8
+  export LANG=de_DE.UTF-8
+
+  source ${SPREAD_PATH}/tests/lib/uutils.sh
+  source ${SPREAD_PATH}/tests/lib/sudo-rs.sh
+
+  oxidizr enable --yes
+  oxidizr disable --yes --experiments coreutils
+
+  export LC_ALL=en_GB.UTF-8
+  export LANGUAGE=en_GB.UTF-8
+  export LANG=en_GB.UTF-8
+
+  ensure_coreutils_absent
+  ensure_sudors_installed
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    oxidizr disable --yes --all
+  fi


### PR DESCRIPTION
Before this commit, `oxidizr` checked if packages were installed by checking for the word `installed` in the output of `apt list <pkg>`, which works fine all the time `apt` is in English, but not so well if the system uses a different locale.

This commit instead relies upon `dpkg-query -s`, which fails if the package is not installed.

Fixes #9 