### PR TITLE
feat: add no compatibility check option for enabling experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Options:
 
           [default: coreutils sudo-rs]
 
+  --no-compatibility-check
+          Skip compatibility checks (dangerous)
+          This bypasses all system compatibility checks including Ubuntu distribution
+          and version requirements. May lead to system instability.
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -89,6 +94,12 @@ sudo oxidizr enable --all
 sudo oxidizr enable --experiments coreutils findutils
 # Enable just coreutils experiment without prompting with debug logging enabled
 sudo oxidizr enable --experiments coreutils --yes -v
+
+# Enable an experiment on an unsupported system (dangerous)
+sudo oxidizr enable --no-compatibility-check
+
+# Enable an experiment on an unsupported system without prompting (very dangerous)
+sudo oxidizr enable --no-compatibility-check --yes
 ```
 
 ## Building `oxidizr`

--- a/src/experiments/mod.rs
+++ b/src/experiments/mod.rs
@@ -20,8 +20,8 @@ impl Experiment<'_> {
         }
     }
 
-    pub fn enable(&self) -> Result<()> {
-        if !self.check_compatible() {
+    pub fn enable(&self, no_compatibility_check: bool) -> Result<()> {
+        if !no_compatibility_check && !self.check_compatible() {
             warn!(
                 "Skipping '{}'. Minimum supported release is {}.",
                 self.name(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,21 +143,6 @@ fn enable(
     yes: bool,
     no_compatibility_check: bool,
 ) -> Result<()> {
-    // If not using --yes and using --no-compatibility-check, show a specific warning and confirm
-    if !yes && no_compatibility_check {
-        let ans = Confirm::new("Skip compatibility checks?")
-            .with_default(false)
-            .with_help_message("⚠️ Skipping compatibility checks is dangerous! ⚠️\nThis may lead to system instability or failure to boot.\nOnly proceed if you understand the risks.")
-            .prompt();
-
-        match ans {
-            Ok(true) => (),
-            Ok(false) => exit(1),
-            Err(_) => exit(1),
-        }
-    }
-
-    // Regular confirmation prompt
     confirm_or_exit(yes);
 
     info!("Updating apt package cache");

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,14 @@ struct Args {
     all: bool,
 
     #[arg(
+        long,
+        default_value_t = false,
+        global = true,
+        help = "Skip compatibility checks (dangerous)"
+    )]
+    no_compatibility_check: bool,
+
+    #[arg(
         short,
         long,
         global = true,
@@ -108,31 +116,55 @@ fn main() -> Result<()> {
     // Initialise the system, gather system information.
     let system = System::new()?;
 
-    // Exit if the application is run on a non-Ubuntu machine.
-    anyhow::ensure!(
-        system.distribution()?.id == "Ubuntu",
-        "This program only supports Ubuntu"
-    );
+    // Exit if the application is run on a non-Ubuntu machine (unless compatibility check is skipped).
+    if !args.no_compatibility_check {
+        anyhow::ensure!(
+            system.distribution()?.id == "Ubuntu",
+            "This program only supports Ubuntu"
+        );
+    } else if system.distribution()?.id != "Ubuntu" {
+        warn!("Running on a non-Ubuntu distribution. This is unsupported and may cause system instability.");
+    }
 
     // Get selected experiments from the command line arguments
     let selected = selected_experiments(args.all, args.experiments.clone(), &system);
 
     // Handle subcommands
     match args.cmd {
-        Commands::Enable => enable(&system, selected, args.yes),
+        Commands::Enable => enable(&system, selected, args.yes, args.no_compatibility_check),
         Commands::Disable => disable(selected, args.yes),
     }
 }
 
 /// Enables selected experiments
-fn enable(system: &impl Worker, experiments: Vec<Experiment>, yes: bool) -> Result<()> {
+fn enable(
+    system: &impl Worker,
+    experiments: Vec<Experiment>,
+    yes: bool,
+    no_compatibility_check: bool,
+) -> Result<()> {
+    // If not using --yes and using --no-compatibility-check, show a specific warning and confirm
+    if !yes && no_compatibility_check {
+        let ans = Confirm::new("Skip compatibility checks?")
+            .with_default(false)
+            .with_help_message("⚠️ Skipping compatibility checks is dangerous! ⚠️\nThis may lead to system instability or failure to boot.\nOnly proceed if you understand the risks.")
+            .prompt();
+
+        match ans {
+            Ok(true) => (),
+            Ok(false) => exit(1),
+            Err(_) => exit(1),
+        }
+    }
+
+    // Regular confirmation prompt
     confirm_or_exit(yes);
 
     info!("Updating apt package cache");
     system.update_package_lists()?;
 
     for e in experiments.iter() {
-        e.enable()?;
+        e.enable(no_compatibility_check)?;
     }
     Ok(())
 }

--- a/tests/enable-no-compatibility-check/task.yaml
+++ b/tests/enable-no-compatibility-check/task.yaml
@@ -1,0 +1,16 @@
+summary: Test enabling experiments with --no-compatibility-check flag
+execute: |
+  source ${SPREAD_PATH}/tests/lib/uutils.sh
+  source ${SPREAD_PATH}/tests/lib/sudo-rs.sh
+  
+  oxidizr enable --yes --no-compatibility-check --experiments coreutils findutils sudo-rs
+  
+  # Verify that the experiments were actually enabled
+  ensure_coreutils_installed
+  ensure_findutils_installed
+  ensure_sudors_installed
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    oxidizr disable --yes --experiments coreutils findutils sudo-rs --no-compatibility-check
+  fi


### PR DESCRIPTION
This would skip check for Ubuntu distro and experiment specific checks.

This would satisfy needs from the #7 and #11 to run this on distros which are not supported.